### PR TITLE
Missing request method in controller methods will no longer crash the server

### DIFF
--- a/lib/expressController.js
+++ b/lib/expressController.js
@@ -94,12 +94,16 @@ module.exports = {
 		methodName = methodName.toLowerCase();
 		parameters = parameters || [];
 		
-		// Return false if this method is missing a request method (get_/post_/...)
-		if(methodName.indexOf('_') < 1) return false;
-		
 		var parts = methodName.split('_');
+		
 		//Extract the method from parts
 		var method = parts[0];
+		
+		// Return false if this request method is not valid
+		// or if the action name is missing
+		if(['get', 'post', 'put', 'delete'].indexOf(method) == -1) return false;
+		if(parts.length < 1) return false;
+
 		//Remove method from parts
 		parts.splice(0, 1);
 

--- a/tests/expressControllerTest-integration.js
+++ b/tests/expressControllerTest-integration.js
@@ -64,5 +64,21 @@ module.exports = {
 		expressControllers.bind(app, function() {
 			test.done();
 		});
-	}
+	},
+
+	ignoreBindingWithoutRequestMethod: function(test) {
+		var controllersDir = __dirname + '/mock/ignoreBindingWithoutRequestMethod/';
+		expressControllers
+			.setDirectory(controllersDir);
+		test.expect(1); // There's 1  valid method out of 3 in mock
+		var app = {
+			get : function(path, method) {
+				test.equal(path, '/people');
+			}
+		};
+		
+		expressControllers.bind(app, function() {
+			test.done();
+		});
+	}  
 }

--- a/tests/expressControllerTest-unit.js
+++ b/tests/expressControllerTest-unit.js
@@ -33,6 +33,12 @@ module.exports = {
 		test.done();
 	},
 
+	translateMethodWithoutRequest : function(test) {
+		var res = expressControllers.translatePath('index', 'home');
+		test.strictEqual(res, false);
+		test.done();
+	},
+
 	translatePeopleIndex : function(test) {
 		var res = expressControllers.translatePath('get_index', 'people');
 		test.equal(res.path, '/people');

--- a/tests/mock/ignoreBindingWithoutRequestMethod/PeopleController.js
+++ b/tests/mock/ignoreBindingWithoutRequestMethod/PeopleController.js
@@ -1,0 +1,13 @@
+module.exports = {
+	find : function(req, res) {
+
+	},
+
+	get_index : function(req, res) {
+
+	},
+
+	phony_find : function(req, res) {
+
+	}
+}


### PR DESCRIPTION
Added support for controller methods without the need of a request method.
These methods will be ignored in the routing process, but will be callable from other methods.
They will also not crash the server on start up.
