### PR TITLE
Contains fix for path resolve conflict

### DIFF
--- a/lib/expressController.js
+++ b/lib/expressController.js
@@ -27,11 +27,14 @@ module.exports = {
 				var aliases = controller['aliases'] || [];
 				delete controller['aliases'];
 				aliases.push(self.translateFileNameToControllerName(file));
+
+				var paths = [];
+
 				for(var key in controller) {
 					//The function in the controller
 					var f = controller[key];
 					var middlewareFunctions = undefined;
-					
+
 					//Array of route middleware support
 					if(Array.isArray(f)) {
 						if(f.length == 1) {
@@ -43,24 +46,33 @@ module.exports = {
 							f = controllerFunction;
 						}
 						else {
-							throw new Error('No controller function defined');	
+							throw new Error('No controller function defined');
 						}
 					}
-					
+
 					//The parameters in the controller-function
 					var params = self.translateFunctionBodyToParameterArray(f);
-				
+
 					aliases.forEach(function(alias) {
 						//The generated path (method and url)
 						var path = self.translatePath(key, alias, params);
 						//Does this function translate to a valid path for routing?
 						if(path !== false) {
-							//Binds the route in the app to the method
 							self.pathMiddlewares[path.method.toLowerCase()+path.path] = middlewareFunctions;
-							self.bindFunction(app, path, params, f);
+							var pathObj = {path: path, params: params, f: f};
+							paths.push(pathObj);
 						}
 					});
 				}
+
+				paths.sort(function(a, b){
+					return b.path.path.localeCompare(a.path.path);
+				});
+
+				paths.forEach(function(pathObj){
+					//Binds the route in the app to the method
+					self.bindFunction(app, pathObj.path, pathObj.params, pathObj.f);
+				})
 			});
 			if(cb) {
 				cb();
@@ -69,14 +81,14 @@ module.exports = {
 	},
 
 	bindFunction : function(app, path, params, f) {
-		
+
 		var self = this;
 
 		var pathKey = path.method.toLowerCase()+path.path;
 
 		self.pathParams[pathKey] = params;
 		self.pathFunctions[pathKey] = f;
-		
+
 		if(self.pathMiddlewares[pathKey] && Array.isArray(self.pathMiddlewares[pathKey])) {
 
 			app[path.method.toLowerCase()](
@@ -106,7 +118,7 @@ module.exports = {
 			);
 
 		}
-		
+
 	},
 
 	translateKeysArrayToValuesArray : function(keysArray, keyValueObject) {
@@ -118,13 +130,13 @@ module.exports = {
 	},
 
 	translateFunctionBodyToParameterArray : function(f) {
-		
+
 		if (typeof f == 'function') {
 			var params = f.toString()
 			  .replace(/((\/\/.*$)|(\/\*[\s\S]*?\*\/)|(\s))/mg,'')
 			  .match(/^function\s*[^\(]*\(\s*([^\)]*)\)/m)[1]
 			  .split(/,/)
-			
+
 			if(params.length >= 2) {
 				params.splice(0,2);
 				return params;
@@ -136,27 +148,27 @@ module.exports = {
 		else {
 			throw new Error('Defined controller object is not a function');
 		}
-		
+
 	},
 
 	translateFileNameToControllerName : function(fileName) {
 		return fileName
-			.slice(	0, 
+			.slice(0,
 					//Get everything before the last dot
 					fileName.lastIndexOf('.'))
 			.replace('Controller', '');
 	},
-	
+
 	translatePath : function(methodName, controllerName, parameters) {
 		//Ensure that both strings are lower-case
 		controllerName = controllerName.toLowerCase();
 		parameters = parameters || [];
-		
+
 		var parts = methodName.split('_');
-		
+
 		//Extract the method from parts
 		var method = parts[0].toLowerCase();
-		
+
 		// Return false if this request method is not valid
 		// or if the action name is missing
 		if(['get', 'post', 'put', 'delete'].indexOf(method) == -1) return false;
@@ -166,21 +178,20 @@ module.exports = {
 		parts.splice(0, 1);
 
 		var path = '/';
-		
+
 		//Append controller-name to path, if different from 'home'
 		if(controllerName != 'home')
 			path += controllerName;
-		
+
 		//Append the rest of the parts
 		parts.forEach(function(part) {
 			if(part != 'index') {
 				var separator = !!~parameters.indexOf(part) ? '/:' : '/';
-				if(separator == '/'){
-		                    //Replaces the camelCased section with a hyphenated lowercase string
-		                    part = part.replace(/([A-Z])/g, '-$1').toLowerCase();
-		                }
+				if(separator == '/') {
+					//Replaces the camelCased section with a hyphenated lowercase string
+					part = part.replace(/([A-Z])/g, '-$1').toLowerCase();
+				}
 				path += separator + part;
-
 			}
 		});
 

--- a/tests/expressControllerTest-integration.js
+++ b/tests/expressControllerTest-integration.js
@@ -12,12 +12,12 @@ module.exports = {
 				test.equal(path, '/');
 			}
 		};
-		
+
 		expressControllers.bind(app, function() {
 			test.done();
 		});
 	},
-	
+
 	bindingPeopleFind : function(test) {
 		var controllersDir = __dirname + '/mock/bindingPeopleFind/';
 		expressControllers
@@ -28,12 +28,12 @@ module.exports = {
 				test.equal(path, '/people/find');
 			}
 		};
-		
+
 		expressControllers.bind(app, function() {
 			test.done();
 		});
 	},
-	
+
 	bindingPeopleFriends : function(test) {
 		var controllersDir = __dirname + '/mock/bindingPeopleFriends/';
 		expressControllers
@@ -44,7 +44,7 @@ module.exports = {
 				test.equal(path, '/people/:id/friends');
 			}
 		};
-		
+
 		expressControllers.bind(app, function() {
 			test.done();
 		});
@@ -60,7 +60,7 @@ module.exports = {
 				test.equal(method.toString(), 'function (req, res) {\n\t\t\t\t\tvar reqKey = req.method.toLowerCase()+req.route.path;\n\t\t\t\t\tvar clonedParams = self.pathParams[reqKey].slice(0);\n\t\t\t\t\tclonedParams = self.translateKeysArrayToValuesArray(clonedParams, req.params);\n\t\t\t\t\tclonedParams.unshift(req, res);\n\t\t\t\t\tself.pathFunctions[reqKey].apply(self, clonedParams);\n\t\t\t\t}');
 			}
 		};
-		
+
 		expressControllers.bind(app, function() {
 			test.done();
 		});
@@ -68,19 +68,19 @@ module.exports = {
 
 	middlewareFunctions: function(test) {
 		var controllersDir = __dirname + '/mock/middlewareFunctions/';
-                
-		expressControllers
-                        .setDirectory(controllersDir);
-                test.expect(1);
-                var app = {
-                        get : function(path, method) {
-                                test.equal(method.toString(), 'function (req, res, next){}');
-                        }
-                };
 
-                expressControllers.bind(app, function() {
-                        test.done();
-                });
+		expressControllers
+						.setDirectory(controllersDir);
+				test.expect(1);
+				var app = {
+						get : function(path, method) {
+								test.equal(method.toString(), 'function (req, res, next){}');
+						}
+				};
+
+				expressControllers.bind(app, function() {
+						test.done();
+				});
 	},
 
 	ignoreBindingWithoutRequestMethod: function(test) {
@@ -93,7 +93,7 @@ module.exports = {
 				test.equal(path, '/people');
 			}
 		};
-		
+
 		expressControllers.bind(app, function() {
 			test.done();
 		});
@@ -123,13 +123,13 @@ module.exports = {
 			get : function(path, method) {
 				urls.push(path);
 				if(urls.length == 3) {
-					test.equal(urls[0], '/alias');
+					test.equal(urls[2], '/alias');
 					test.equal(urls[1], '/alias2');
-					test.equal(urls[2], '/test');
+					test.equal(urls[0], '/test');
 				}
 			}
 		};
-		
+
 		expressControllers.bind(app, function() {
 			test.done();
 		});


### PR DESCRIPTION
For example lets say we have a controller named "people" that has the following two functions:

```
//Translates to /people/:id
get_id: function(req, res, id) {

},

//Translates to /people/edit
get_edit: function(req, res) {

}
```

For the above case, the former function overwrites the later and /people/edit would return a 404.

To solve this issue, I've sorted all the routes in such a way that all the variable routes are defined after the other routes are defined. This solves the problem.