### PR TITLE
Fixing head request crashing express

### DIFF
--- a/lib/expressController.js
+++ b/lib/expressController.js
@@ -98,6 +98,7 @@ module.exports = {
 				self.pathMiddlewares[pathKey],
 				function(req, res) {
 					var reqKey = req.method.toLowerCase()+req.route.path;
+					if(!self.pathParams[reqKey]) reqKey = 'get'+req.route.path;
 					var clonedParams = self.pathParams[reqKey].slice(0);
 					clonedParams = self.translateKeysArrayToValuesArray(clonedParams, req.params);
 					clonedParams.unshift(req, res);
@@ -112,6 +113,7 @@ module.exports = {
 				path.path,
 				function(req, res) {
 					var reqKey = req.method.toLowerCase()+req.route.path;
+					if(!self.pathParams[reqKey]) reqKey = 'get'+req.route.path;
 					var clonedParams = self.pathParams[reqKey].slice(0);
 					clonedParams = self.translateKeysArrayToValuesArray(clonedParams, req.params);
 					clonedParams.unshift(req, res);

--- a/tests/expressControllerTest-integration.js
+++ b/tests/expressControllerTest-integration.js
@@ -57,7 +57,7 @@ module.exports = {
 		test.expect(1);
 		var app = {
 			get : function(path, method) {
-				test.equal(method.toString(), 'function (req, res) {\n\t\t\t\t\tvar reqKey = req.method.toLowerCase()+req.route.path;\n\t\t\t\t\tvar clonedParams = self.pathParams[reqKey].slice(0);\n\t\t\t\t\tclonedParams = self.translateKeysArrayToValuesArray(clonedParams, req.params);\n\t\t\t\t\tclonedParams.unshift(req, res);\n\t\t\t\t\tself.pathFunctions[reqKey].apply(self, clonedParams);\n\t\t\t\t}');
+				test.equal(method.toString(), 'function (req, res) {\n\t\t\t\t\tvar reqKey = req.method.toLowerCase()+req.route.path;\n\t\t\t\t\tif(!self.pathParams[reqKey]) reqKey = \'get\'+req.route.path;\n\t\t\t\t\tvar clonedParams = self.pathParams[reqKey].slice(0);\n\t\t\t\t\tclonedParams = self.translateKeysArrayToValuesArray(clonedParams, req.params);\n\t\t\t\t\tclonedParams.unshift(req, res);\n\t\t\t\t\tself.pathFunctions[reqKey].apply(self, clonedParams);\n\t\t\t\t}');
 			}
 		};
 


### PR DESCRIPTION
If http head request method is not defined in the controller, express tries to call the get method and simulates the head request by using the get request. In this case the module crashes because it tries to access the head method though that does not exist.