### PR TITLE
Add support for ES2015

### DIFF
--- a/lib/expressController.js
+++ b/lib/expressController.js
@@ -1,5 +1,6 @@
 var file = require('file');
 var path = require('path');
+var getParams = require('get-parameter-names');
 
 module.exports = {
 
@@ -137,19 +138,15 @@ module.exports = {
 	},
 
 	translateFunctionBodyToParameterArray : function(f) {
-		if (typeof f == 'function') {
-			var params = f.toString()
-			  .replace(/((\/\/.*$)|(\/\*[\s\S]*?\*\/)|(\s))/mg,'')
-			  .match(/^function\s*[^\(]*\(\s*([^\)]*)\)/m)[1]
-			  .split(/,/)
-
-			if(params.length >= 2) {
-				params.splice(0,2);
-				return params;
-			}
-			else throw new Error('Defined controller function has too few parameters');
+		if (typeof f != 'function') {
+            throw new Error('Defined controller object is not a function');
 		}
-		else throw new Error('Defined controller object is not a function');
+		var params = getParams(f);
+		if (params.length < 2) {
+            throw new Error('Defined controller function has too few parameters');
+		}
+		params.splice(0, 2);
+		return params;
 	},
 
 	translateFileNameToControllerName : function(fileName) {

--- a/lib/expressController.js
+++ b/lib/expressController.js
@@ -139,11 +139,11 @@ module.exports = {
 
 	translateFunctionBodyToParameterArray : function(f) {
 		if (typeof f != 'function') {
-            throw new Error('Defined controller object is not a function');
+			throw new Error('Defined controller object is not a function');
 		}
 		var params = getParams(f);
 		if (params.length < 2) {
-            throw new Error('Defined controller function has too few parameters');
+			throw new Error('Defined controller function has too few parameters');
 		}
 		params.splice(0, 2);
 		return params;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.0",
   "dependencies": {
     "file": "^0.2.2",
+    "get-parameter-names": "^0.3.0",
     "nodeunit": "*"
   },
   "scripts": {

--- a/tests/expressControllerTest-integration.js
+++ b/tests/expressControllerTest-integration.js
@@ -133,5 +133,27 @@ module.exports = {
 		expressControllers.bind(app, function() {
 			test.done();
 		});
-	}
+	},
+
+    es2015Support : function(test) {
+        var controllersDir = __dirname + '/mock/es2015Support/';
+        expressControllers
+            .setDirectory(controllersDir);
+        test.expect(3);
+        var urls = [];
+        var app = {
+            get : function(path, method) {
+                urls.push(path);
+                if(urls.length == 3) {
+                    test.equal(urls[2], '/es2015/a');
+                    test.equal(urls[1], '/es2015/b');
+                    test.equal(urls[0], '/es2015/c');
+                }
+            }
+        };
+
+        expressControllers.bind(app, function() {
+            test.done();
+        });
+    },
 }

--- a/tests/expressControllerTest-unit.js
+++ b/tests/expressControllerTest-unit.js
@@ -71,8 +71,40 @@ module.exports = {
 		test.equal(res[1], 'parameter2');
 		test.done();
 	},
+	translateFunctionBodyToParameterArrayDefaultsSupport : function(test) {
+        var body = function(){};
+        body.toString = function() {
+            return 'function (req, res, parameter1, parameter2 = 23) {}';
+        };
+		var res = expressControllers.translateFunctionBodyToParameterArray(body);
+		test.equal(res[0], 'parameter1');
+		test.equal(res[1], 'parameter2');
+		test.done();
+	},
 
-	//Issure #4
+	translateFunctionBodyToParameterArrayArrowSupport : function(test) {
+		var body = function(){};
+		body.toString = function() {
+			return '(req, res, parameter1, parameter2) => {}';
+		};
+		var res = expressControllers.translateFunctionBodyToParameterArray(body);
+		test.equal(res[0], 'parameter1');
+		test.equal(res[1], 'parameter2');
+		test.done();
+	},
+
+	translateFunctionBodyToParameterArrayArrowDefaultsSupport : function(test) {
+		var body = function(){};
+		body.toString = function() {
+			return '(req, res, parameter1, parameter2 = 23) => {}';
+		};
+		var res = expressControllers.translateFunctionBodyToParameterArray(body);
+		test.equal(res[0], 'parameter1');
+		test.equal(res[1], 'parameter2');
+		test.done();
+	},
+
+	//Issue #4
 	translateFunctionBodyWithInnerParameters : function(test) {
 		var body = function (req, res) { function test(val1, val2, val3) {} };
 		var res = expressControllers.translateFunctionBodyToParameterArray(body);

--- a/tests/mock/es2015Support/es2015Controller.js
+++ b/tests/mock/es2015Support/es2015Controller.js
@@ -1,0 +1,23 @@
+var controller = {
+	get_a : function(req, res) {
+		
+	},
+	get_b : function(req, res) {
+
+	},
+	get_c : function(req, res) {
+
+	}
+};
+
+controller.get_a.toString = function() {
+	return 'function(req, res = 2) {}';
+};
+controller.get_b.toString = function() {
+	return '(req, res) => {}';
+};
+controller.get_c.toString = function() {
+	return '(req, res = 2) => {}';
+};
+
+module.exports = controller;


### PR DESCRIPTION
Previously a custom regex was made to obtain the params of a function.

I propose to use the library [goatslacker/get-parameters-name](https://github.com/goatslacker/get-parameter-names) to obtain the params. It supports ES2015 like arrows and param defaults.